### PR TITLE
Add Forest Friends Picnic mini-game

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,15 @@ Explore a magical castle in this enchanting adventure game. Discover rooms, coll
 - 🎨 Beautiful Graphics
 - 🎯 Educational Spelling Challenges
 
+### 🌲 Forest Friends Picnic
+Join woodland pals for a cozy picnic! Listen to each friend’s clue and pick the snack that matches their favorite forest treat.
+
+**Features:**
+- 🦊 Adorable Animal Cast
+- 🧠 Listening & Deduction Practice
+- 🌟 Calming Visual Celebrations
+- 📱 Optimized for Touch and Desktop
+
 ## 🚀 Getting Started
 
 1. **Play Online**: Simply open `index.html` in your web browser to access the game collection landing page
@@ -46,6 +55,8 @@ ellie/
 ├── animal-adventure/       # Eleanor's Animal Adventure game
 ├── animal-matching/        # Animal Matching game
 ├── princess-castle/        # Princess Castle Adventure game
+├── princess-coffee-shop/   # Princess Coffee Shop game
+├── forest-picnic/          # Forest Friends Picnic game
 ├── README.md              # This file
 └── assets/                # Shared images and resources
 ```

--- a/forest-picnic/assets/animal-bunny.svg
+++ b/forest-picnic/assets/animal-bunny.svg
@@ -1,0 +1,33 @@
+<svg width="420" height="360" viewBox="0 0 420 360" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="420" height="360" rx="48" fill="url(#bg)"/>
+  <g filter="url(#shadow)">
+    <path d="M140 100C128 56 148 36 164 36C188 36 208 72 208 102C208 132 186 152 170 150C154 148 148 124 140 100Z" fill="#FBD2E6"/>
+    <path d="M280 100C292 56 272 36 256 36C232 36 212 72 212 102C212 132 234 152 250 150C266 148 272 124 280 100Z" fill="#FBD2E6"/>
+    <ellipse cx="210" cy="220" rx="96" ry="118" fill="#FFF7FA"/>
+    <ellipse cx="178" cy="214" rx="18" ry="24" fill="#2D2220"/>
+    <ellipse cx="242" cy="214" rx="18" ry="24" fill="#2D2220"/>
+    <circle cx="178" cy="208" r="5" fill="white"/>
+    <circle cx="242" cy="208" r="5" fill="white"/>
+    <path d="M210 230C198 230 188 240 188 252C188 264 198 274 210 274C222 274 232 264 232 252C232 240 222 230 210 230Z" fill="#F4A1C3"/>
+    <path d="M210 274C198 274 188 282 188 292C188 302 198 310 210 310C222 310 232 302 232 292C232 282 222 274 210 274Z" fill="#2D2220"/>
+    <path d="M140 250C160 270 180 280 210 280C240 280 260 270 280 250" stroke="#F4A1C3" stroke-width="16" stroke-linecap="round"/>
+    <circle cx="170" cy="182" r="12" fill="#F4A1C3"/>
+    <circle cx="250" cy="182" r="12" fill="#F4A1C3"/>
+  </g>
+  <g opacity="0.7">
+    <ellipse cx="120" cy="310" rx="38" ry="18" fill="#5DAA72"/>
+    <ellipse cx="310" cy="308" rx="40" ry="18" fill="#5DAA72"/>
+    <ellipse cx="212" cy="320" rx="92" ry="22" fill="#5DAA72"/>
+  </g>
+  <defs>
+    <linearGradient id="bg" x1="210" y1="0" x2="210" y2="360" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#FFF5FB"/>
+      <stop offset="1" stop-color="#FFE1F2"/>
+    </linearGradient>
+    <filter id="shadow" x="80" y="20" width="260" height="320" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feOffset dy="8"/>
+      <feGaussianBlur stdDeviation="12" result="blur"/>
+      <feBlend in="SourceGraphic" in2="blur" mode="normal"/>
+    </filter>
+  </defs>
+</svg>

--- a/forest-picnic/assets/animal-deer.svg
+++ b/forest-picnic/assets/animal-deer.svg
@@ -1,0 +1,34 @@
+<svg width="420" height="360" viewBox="0 0 420 360" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="420" height="360" rx="48" fill="url(#bg)"/>
+  <g filter="url(#shadow)">
+    <path d="M120 270C120 198 168 130 210 130C252 130 300 198 300 270C300 312 260 322 210 322C160 322 120 312 120 270Z" fill="#F5D9B0"/>
+    <path d="M172 150C154 118 126 98 100 98C82 98 68 106 60 120C88 126 110 138 130 158L172 150Z" fill="#D8B48B"/>
+    <path d="M248 150C266 118 294 98 320 98C338 98 352 106 360 120C332 126 310 138 290 158L248 150Z" fill="#D8B48B"/>
+    <path d="M210 268C244 268 270 244 270 210C270 176 244 148 210 148C176 148 150 176 150 210C150 244 176 268 210 268Z" fill="#EBCDA2"/>
+    <ellipse cx="182" cy="212" rx="16" ry="22" fill="#2D2220"/>
+    <ellipse cx="238" cy="212" rx="16" ry="22" fill="#2D2220"/>
+    <circle cx="178" cy="206" r="4" fill="white"/>
+    <circle cx="234" cy="206" r="4" fill="white"/>
+    <path d="M210 216C202 216 196 222 196 230C196 238 202 244 210 244C218 244 224 238 224 230C224 222 218 216 210 216Z" fill="#2D2220"/>
+    <path d="M210 244C198 244 188 254 188 266C188 278 198 288 210 288C222 288 232 278 232 266C232 254 222 244 210 244Z" fill="#F7B36B"/>
+    <circle cx="178" cy="180" r="10" fill="#F7B36B"/>
+    <circle cx="242" cy="180" r="10" fill="#F7B36B"/>
+    <path d="M150 254C168 268 188 276 210 276C232 276 252 268 270 254" stroke="#DAAF74" stroke-width="14" stroke-linecap="round"/>
+  </g>
+  <g opacity="0.7">
+    <ellipse cx="118" cy="312" rx="36" ry="18" fill="#5DAA72"/>
+    <ellipse cx="304" cy="314" rx="38" ry="18" fill="#5DAA72"/>
+    <ellipse cx="210" cy="326" rx="90" ry="22" fill="#5DAA72"/>
+  </g>
+  <defs>
+    <linearGradient id="bg" x1="210" y1="0" x2="210" y2="360" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#FFF5E3"/>
+      <stop offset="1" stop-color="#FFE7C8"/>
+    </linearGradient>
+    <filter id="shadow" x="60" y="80" width="300" height="300" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feOffset dy="8"/>
+      <feGaussianBlur stdDeviation="12" result="blur"/>
+      <feBlend in="SourceGraphic" in2="blur" mode="normal"/>
+    </filter>
+  </defs>
+</svg>

--- a/forest-picnic/assets/animal-fox.svg
+++ b/forest-picnic/assets/animal-fox.svg
@@ -1,0 +1,32 @@
+<svg width="420" height="360" viewBox="0 0 420 360" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="420" height="360" rx="48" fill="url(#bg)"/>
+  <g filter="url(#shadow)">
+    <path d="M120 260C120 210 160 120 210 120C260 120 300 210 300 260C300 310 260 320 210 320C160 320 120 310 120 260Z" fill="#FFB07B"/>
+    <path d="M160 248C160 222 178 190 210 190C242 190 260 222 260 248C260 274 242 292 210 292C178 292 160 274 160 248Z" fill="white" opacity="0.9"/>
+    <path d="M210 220C230 220 246 208 246 194C246 172 228 150 210 150C192 150 174 172 174 194C174 208 190 220 210 220Z" fill="#FF9559"/>
+    <ellipse cx="190" cy="206" rx="12" ry="14" fill="#2D2220"/>
+    <ellipse cx="230" cy="206" rx="12" ry="14" fill="#2D2220"/>
+    <circle cx="190" cy="202" r="4" fill="white"/>
+    <circle cx="230" cy="202" r="4" fill="white"/>
+    <path d="M210 224C202 224 194 230 194 238C194 246 202 252 210 252C218 252 226 246 226 238C226 230 218 224 210 224Z" fill="#2D2220"/>
+    <path d="M180 150L134 132C116 126 102 108 102 88V76C126 84 158 110 180 150Z" fill="#FF9559"/>
+    <path d="M240 150L286 132C304 126 318 108 318 88V76C294 84 262 110 240 150Z" fill="#FF9559"/>
+    <path d="M130 268C160 282 190 290 210 290C230 290 260 282 290 268" stroke="#F7744A" stroke-width="14" stroke-linecap="round"/>
+  </g>
+  <g opacity="0.7">
+    <ellipse cx="110" cy="310" rx="36" ry="20" fill="#5DAA72"/>
+    <ellipse cx="310" cy="310" rx="42" ry="18" fill="#5DAA72"/>
+    <ellipse cx="210" cy="320" rx="90" ry="22" fill="#5DAA72"/>
+  </g>
+  <defs>
+    <linearGradient id="bg" x1="210" y1="0" x2="210" y2="360" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#FFF4EA"/>
+      <stop offset="1" stop-color="#FFE7D1"/>
+    </linearGradient>
+    <filter id="shadow" x="60" y="40" width="300" height="300" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feOffset dy="8"/>
+      <feGaussianBlur stdDeviation="12" result="blur"/>
+      <feBlend in="SourceGraphic" in2="blur" mode="normal"/>
+    </filter>
+  </defs>
+</svg>

--- a/forest-picnic/assets/animal-owl.svg
+++ b/forest-picnic/assets/animal-owl.svg
@@ -1,0 +1,33 @@
+<svg width="420" height="360" viewBox="0 0 420 360" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="420" height="360" rx="48" fill="url(#bg)"/>
+  <g filter="url(#shadow)">
+    <path d="M120 270C120 190 168 120 210 120C252 120 300 190 300 270C300 310 260 320 210 320C160 320 120 310 120 270Z" fill="#D8E4FF"/>
+    <path d="M210 260C250 260 286 240 286 200C286 160 250 130 210 130C170 130 134 160 134 200C134 240 170 260 210 260Z" fill="#AFC3F9"/>
+    <circle cx="170" cy="200" r="40" fill="#F8FBFF"/>
+    <circle cx="250" cy="200" r="40" fill="#F8FBFF"/>
+    <circle cx="170" cy="200" r="18" fill="#2D2220"/>
+    <circle cx="250" cy="200" r="18" fill="#2D2220"/>
+    <circle cx="162" cy="192" r="6" fill="white"/>
+    <circle cx="242" cy="192" r="6" fill="white"/>
+    <path d="M210 198C202 198 198 204 198 210C198 216 202 220 210 220C218 220 222 216 222 210C222 204 218 198 210 198Z" fill="#F7A94C"/>
+    <path d="M160 250C176 260 196 266 210 266C224 266 244 260 260 250" stroke="#8398DB" stroke-width="14" stroke-linecap="round"/>
+    <path d="M150 146C140 130 124 122 108 122C96 122 86 128 80 138C106 146 128 156 150 170V146Z" fill="#AFC3F9"/>
+    <path d="M270 146C280 130 296 122 312 122C324 122 334 128 340 138C314 146 292 156 270 170V146Z" fill="#AFC3F9"/>
+  </g>
+  <g opacity="0.65">
+    <ellipse cx="120" cy="314" rx="36" ry="18" fill="#5DAA72"/>
+    <ellipse cx="300" cy="312" rx="38" ry="18" fill="#5DAA72"/>
+    <ellipse cx="210" cy="326" rx="88" ry="20" fill="#5DAA72"/>
+  </g>
+  <defs>
+    <linearGradient id="bg" x1="210" y1="0" x2="210" y2="360" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#F5F8FF"/>
+      <stop offset="1" stop-color="#E0EBFF"/>
+    </linearGradient>
+    <filter id="shadow" x="60" y="80" width="300" height="280" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feOffset dy="8"/>
+      <feGaussianBlur stdDeviation="12" result="blur"/>
+      <feBlend in="SourceGraphic" in2="blur" mode="normal"/>
+    </filter>
+  </defs>
+</svg>

--- a/forest-picnic/assets/background.svg
+++ b/forest-picnic/assets/background.svg
@@ -1,0 +1,69 @@
+<svg width="1200" height="720" viewBox="0 0 1200 720" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="1200" height="720" fill="url(#paint0_radial)"/>
+  <g opacity="0.65">
+    <ellipse cx="598" cy="598" rx="620" ry="240" fill="url(#paint1_radial)"/>
+    <ellipse cx="185" cy="620" rx="320" ry="120" fill="url(#paint2_radial)"/>
+    <ellipse cx="1015" cy="640" rx="300" ry="110" fill="url(#paint3_radial)"/>
+  </g>
+  <g>
+    <path d="M0 560C120 520 230 540 360 570C490 600 640 640 820 600C960 570 1080 560 1200 600V720H0V560Z" fill="url(#paint4_linear)"/>
+    <path d="M0 600C140 560 280 610 430 640C580 670 750 660 920 610C1015 580 1100 580 1200 610V720H0V600Z" fill="url(#paint5_linear)" opacity="0.8"/>
+    <path d="M0 640C160 600 340 650 520 670C700 690 900 660 1200 620V720H0V640Z" fill="url(#paint6_linear)" opacity="0.65"/>
+  </g>
+  <g opacity="0.6">
+    <circle cx="220" cy="420" r="90" fill="#7ED957"/>
+    <circle cx="240" cy="410" r="70" fill="#9BE27E"/>
+    <circle cx="320" cy="440" r="90" fill="#7ED957"/>
+    <circle cx="300" cy="430" r="70" fill="#9BE27E"/>
+    <circle cx="280" cy="460" r="75" fill="#6BCB6B"/>
+  </g>
+  <g opacity="0.65">
+    <circle cx="910" cy="430" r="85" fill="#6BCB6B"/>
+    <circle cx="960" cy="430" r="70" fill="#8CDA86"/>
+    <circle cx="1000" cy="460" r="90" fill="#6BCB6B"/>
+    <circle cx="930" cy="470" r="80" fill="#8CDA86"/>
+  </g>
+  <g opacity="0.5">
+    <circle cx="540" cy="410" r="75" fill="#6BCB6B"/>
+    <circle cx="600" cy="420" r="85" fill="#8CDA86"/>
+    <circle cx="660" cy="410" r="70" fill="#6BCB6B"/>
+  </g>
+  <rect x="120" y="520" width="220" height="50" rx="20" fill="#FCDFA6"/>
+  <rect x="260" y="530" width="240" height="50" rx="25" fill="#F8D28B"/>
+  <rect x="400" y="500" width="380" height="60" rx="30" fill="#FCDFA6"/>
+  <rect x="720" y="520" width="280" height="55" rx="28" fill="#F5C271"/>
+  <rect x="980" y="540" width="160" height="45" rx="22" fill="#FCDFA6"/>
+  <path d="M520 540C540 510 560 500 580 500C600 500 620 520 640 540H520Z" fill="#F6B96F"/>
+  <path d="M640 540C660 510 680 500 700 500C720 500 740 520 760 540H640Z" fill="#F6C77F"/>
+  <defs>
+    <radialGradient id="paint0_radial" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(600 120) rotate(90) scale(620 640)">
+      <stop stop-color="#D1F1FF"/>
+      <stop offset="0.45" stop-color="#F3FBFF"/>
+      <stop offset="1" stop-color="#FFFFFF"/>
+    </radialGradient>
+    <radialGradient id="paint1_radial" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(598 598) rotate(90) scale(240 620)">
+      <stop offset="0.3" stop-color="#F9F0D4"/>
+      <stop offset="1" stop-color="rgba(249, 240, 212, 0)"/>
+    </radialGradient>
+    <radialGradient id="paint2_radial" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(185 620) rotate(90) scale(120 320)">
+      <stop offset="0.3" stop-color="#F9F0D4"/>
+      <stop offset="1" stop-color="rgba(249, 240, 212, 0)"/>
+    </radialGradient>
+    <radialGradient id="paint3_radial" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1015 640) rotate(90) scale(110 300)">
+      <stop offset="0.3" stop-color="#F9F0D4"/>
+      <stop offset="1" stop-color="rgba(249, 240, 212, 0)"/>
+    </radialGradient>
+    <linearGradient id="paint4_linear" x1="0" y1="560" x2="1200" y2="720" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#A1D884"/>
+      <stop offset="1" stop-color="#7FCF6B"/>
+    </linearGradient>
+    <linearGradient id="paint5_linear" x1="0" y1="610" x2="1200" y2="650" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#B6E89B"/>
+      <stop offset="1" stop-color="#8ED07A"/>
+    </linearGradient>
+    <linearGradient id="paint6_linear" x1="0" y1="640" x2="1200" y2="660" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#C5F1AE"/>
+      <stop offset="1" stop-color="#A4D98C"/>
+    </linearGradient>
+  </defs>
+</svg>

--- a/forest-picnic/assets/treat-acorns.svg
+++ b/forest-picnic/assets/treat-acorns.svg
@@ -1,0 +1,23 @@
+<svg width="220" height="200" viewBox="0 0 220 200" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="220" height="200" rx="32" fill="url(#bg)"/>
+  <g filter="url(#shadow)">
+    <path d="M120 152C110 160 96 162 84 156C62 146 56 118 70 96C82 78 106 72 124 82C134 88 140 98 142 110C158 106 174 112 182 126C192 142 188 164 172 174C156 184 134 180 124 166C122 162 122 160 120 156V152Z" fill="url(#acorn)"/>
+    <path d="M80 98C80 78 96 62 118 62C140 62 158 78 158 98" stroke="#9D703E" stroke-width="16" stroke-linecap="round"/>
+    <path d="M104 72C110 60 122 54 134 58C142 60 148 66 152 72" stroke="#9D703E" stroke-width="12" stroke-linecap="round"/>
+  </g>
+  <defs>
+    <linearGradient id="bg" x1="110" y1="0" x2="110" y2="200" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#FFF8ED"/>
+      <stop offset="1" stop-color="#FFEED9"/>
+    </linearGradient>
+    <linearGradient id="acorn" x1="72" y1="82" x2="186" y2="178" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#D8A36B"/>
+      <stop offset="1" stop-color="#B57336"/>
+    </linearGradient>
+    <filter id="shadow" x="40" y="36" width="172" height="160" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feOffset dy="6"/>
+      <feGaussianBlur stdDeviation="10" result="blur"/>
+      <feBlend in="SourceGraphic" in2="blur" mode="normal"/>
+    </filter>
+  </defs>
+</svg>

--- a/forest-picnic/assets/treat-berries.svg
+++ b/forest-picnic/assets/treat-berries.svg
@@ -1,0 +1,23 @@
+<svg width="220" height="200" viewBox="0 0 220 200" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="220" height="200" rx="32" fill="url(#bg)"/>
+  <g filter="url(#shadow)">
+    <path d="M70 150C50 120 64 90 92 84C110 80 130 90 138 108C152 90 184 98 190 120C194 136 186 152 170 158C160 162 148 160 140 152C126 168 100 170 84 160C78 156 74 154 70 150Z" fill="url(#berry)"/>
+    <path d="M94 80C90 60 108 40 126 44C134 46 142 54 144 64" stroke="#5BBE5C" stroke-width="14" stroke-linecap="round"/>
+    <path d="M126 70C126 58 138 50 148 54C154 56 158 62 160 68" stroke="#5BBE5C" stroke-width="12" stroke-linecap="round"/>
+  </g>
+  <defs>
+    <linearGradient id="bg" x1="110" y1="0" x2="110" y2="200" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#FFF7FD"/>
+      <stop offset="1" stop-color="#FFE4F6"/>
+    </linearGradient>
+    <linearGradient id="berry" x1="80" y1="84" x2="182" y2="170" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#FF7BA6"/>
+      <stop offset="1" stop-color="#E23B74"/>
+    </linearGradient>
+    <filter id="shadow" x="40" y="32" width="170" height="150" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feOffset dy="6"/>
+      <feGaussianBlur stdDeviation="10" result="blur"/>
+      <feBlend in="SourceGraphic" in2="blur" mode="normal"/>
+    </filter>
+  </defs>
+</svg>

--- a/forest-picnic/assets/treat-carrots.svg
+++ b/forest-picnic/assets/treat-carrots.svg
@@ -1,0 +1,23 @@
+<svg width="220" height="200" viewBox="0 0 220 200" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="220" height="200" rx="32" fill="url(#bg)"/>
+  <g filter="url(#shadow)">
+    <path d="M108 150C96 134 90 118 90 104C90 86 102 74 118 74C134 74 146 86 146 104C146 118 140 134 128 150L118 164L108 150Z" fill="url(#carrot)"/>
+    <path d="M82 86C84 70 100 58 118 58C136 58 152 70 154 86" stroke="#6BCB6B" stroke-width="14" stroke-linecap="round"/>
+    <path d="M94 74C98 60 110 52 122 52C134 52 146 60 150 72" stroke="#6BCB6B" stroke-width="12" stroke-linecap="round"/>
+  </g>
+  <defs>
+    <linearGradient id="bg" x1="110" y1="0" x2="110" y2="200" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#FFF9EC"/>
+      <stop offset="1" stop-color="#FFEFD1"/>
+    </linearGradient>
+    <linearGradient id="carrot" x1="90" y1="74" x2="146" y2="164" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#FFA24C"/>
+      <stop offset="1" stop-color="#FF7A3D"/>
+    </linearGradient>
+    <filter id="shadow" x="60" y="40" width="140" height="140" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feOffset dy="6"/>
+      <feGaussianBlur stdDeviation="10" result="blur"/>
+      <feBlend in="SourceGraphic" in2="blur" mode="normal"/>
+    </filter>
+  </defs>
+</svg>

--- a/forest-picnic/assets/treat-mushrooms.svg
+++ b/forest-picnic/assets/treat-mushrooms.svg
@@ -1,0 +1,23 @@
+<svg width="220" height="200" viewBox="0 0 220 200" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="220" height="200" rx="32" fill="url(#bg)"/>
+  <g filter="url(#shadow)">
+    <path d="M74 140C64 118 80 92 108 82C132 72 160 80 176 100C188 116 188 138 176 154C170 162 160 166 150 166C140 182 122 190 104 186C88 182 76 168 74 152V140Z" fill="url(#caps)"/>
+    <path d="M104 160C102 148 108 138 118 134C132 128 150 134 156 150" stroke="#F2F9FF" stroke-width="16" stroke-linecap="round"/>
+    <path d="M94 98C94 80 108 66 126 66C144 66 158 80 158 98" stroke="#6AB7FF" stroke-width="14" stroke-linecap="round"/>
+  </g>
+  <defs>
+    <linearGradient id="bg" x1="110" y1="0" x2="110" y2="200" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#F0F8FF"/>
+      <stop offset="1" stop-color="#E0F2FF"/>
+    </linearGradient>
+    <linearGradient id="caps" x1="74" y1="82" x2="186" y2="186" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#B7D4FF"/>
+      <stop offset="1" stop-color="#6CA8FF"/>
+    </linearGradient>
+    <filter id="shadow" x="40" y="40" width="170" height="156" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feOffset dy="6"/>
+      <feGaussianBlur stdDeviation="10" result="blur"/>
+      <feBlend in="SourceGraphic" in2="blur" mode="normal"/>
+    </filter>
+  </defs>
+</svg>

--- a/forest-picnic/index.html
+++ b/forest-picnic/index.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Forest Friends Picnic</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <main class="game-container">
+        <header class="game-header">
+            <h1>🌲 Forest Friends Picnic 🌲</h1>
+            <p>Listen carefully to each forest friend and serve their favorite snack before the sun sets!</p>
+        </header>
+
+        <section class="status-bar" aria-live="polite">
+            <div class="status-pill">Score: <span id="score-value">0</span></div>
+            <div class="status-pill">Round: <span id="round-value">0</span>/10</div>
+            <div class="status-pill">Best Streak: <span id="best-value">0</span></div>
+        </section>
+
+        <section class="scene" aria-live="polite">
+            <img src="assets/background.svg" alt="A cozy forest clearing with a picnic blanket" class="scene-background">
+            <div class="animal-card" id="animal-card">
+                <img src="assets/animal-fox.svg" alt="Forest friend" id="animal-image">
+                <div class="animal-details">
+                    <h2 id="animal-name">Meet Willow the Fox</h2>
+                    <p id="animal-story">Press start to begin the picnic adventure!</p>
+                </div>
+            </div>
+        </section>
+
+        <section class="prompt" aria-live="polite">
+            <p id="prompt-text">Tap “Start Picnic” to hear the next snack request.</p>
+            <button id="start-button" type="button" class="primary-button">Start Picnic</button>
+        </section>
+
+        <section class="treat-grid" aria-label="Forest snacks">
+            <button class="treat-card" data-treat="berries" type="button">
+                <img src="assets/treat-berries.svg" alt="Basket of berries">
+                <span>Forest Berries</span>
+            </button>
+            <button class="treat-card" data-treat="carrots" type="button">
+                <img src="assets/treat-carrots.svg" alt="Crunchy carrots">
+                <span>Crunchy Carrots</span>
+            </button>
+            <button class="treat-card" data-treat="acorns" type="button">
+                <img src="assets/treat-acorns.svg" alt="Acorns">
+                <span>Golden Acorns</span>
+            </button>
+            <button class="treat-card" data-treat="mushrooms" type="button">
+                <img src="assets/treat-mushrooms.svg" alt="Glow mushrooms">
+                <span>Glow Mushrooms</span>
+            </button>
+        </section>
+
+        <section class="feedback" id="feedback" aria-live="polite"></section>
+
+        <footer class="game-footer">
+            <p>Tip: Each friend gives a clue about their favorite snack. Listen closely!</p>
+        </footer>
+    </main>
+
+    <div id="celebration" aria-hidden="true">
+        <div class="sparkle sparkle-1"></div>
+        <div class="sparkle sparkle-2"></div>
+        <div class="sparkle sparkle-3"></div>
+    </div>
+
+    <script src="script.js"></script>
+</body>
+</html>

--- a/forest-picnic/script.js
+++ b/forest-picnic/script.js
@@ -1,0 +1,177 @@
+const MAX_ROUNDS = 10;
+
+const animals = [
+  {
+    id: 'fox',
+    name: 'Willow the Fox',
+    story: 'I dash through the berry bushes each morning. Can you guess my favorite snack?',
+    favoriteTreat: 'berries',
+    image: 'assets/animal-fox.svg'
+  },
+  {
+    id: 'bunny',
+    name: 'Juniper the Bunny',
+    story: 'My ears wiggle when I see something crisp and crunchy from the garden!',
+    favoriteTreat: 'carrots',
+    image: 'assets/animal-bunny.svg'
+  },
+  {
+    id: 'owl',
+    name: 'Sage the Owl',
+    story: 'When the moon glows, I collect twinkling treats that shine softly in the night.',
+    favoriteTreat: 'mushrooms',
+    image: 'assets/animal-owl.svg'
+  },
+  {
+    id: 'deer',
+    name: 'Maple the Deer',
+    story: 'I nibble on crunchy treasures that tumble from the tallest oak trees.',
+    favoriteTreat: 'acorns',
+    image: 'assets/animal-deer.svg'
+  }
+];
+
+const treatDescriptions = {
+  berries: 'A basket of sun-warmed berries collected from the berry patch.',
+  carrots: 'Crunchy carrots freshly pulled from the garden.',
+  acorns: 'Golden acorns gathered from the great oak.',
+  mushrooms: 'Glow mushrooms that light up the twilight picnic.'
+};
+
+const scoreValue = document.getElementById('score-value');
+const roundValue = document.getElementById('round-value');
+const bestValue = document.getElementById('best-value');
+const promptText = document.getElementById('prompt-text');
+const startButton = document.getElementById('start-button');
+const feedback = document.getElementById('feedback');
+const animalCard = document.getElementById('animal-card');
+const animalImage = document.getElementById('animal-image');
+const animalName = document.getElementById('animal-name');
+const animalStory = document.getElementById('animal-story');
+const celebration = document.getElementById('celebration');
+
+const treatButtons = Array.from(document.querySelectorAll('.treat-card'));
+
+let isRoundActive = false;
+let currentAnimal = null;
+let round = 0;
+let score = 0;
+let bestStreak = 0;
+
+function shuffle(array) {
+  const arr = [...array];
+  for (let i = arr.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [arr[i], arr[j]] = [arr[j], arr[i]];
+  }
+  return arr;
+}
+
+function resetTreatButtons(disabled = false) {
+  treatButtons.forEach((button) => {
+    button.disabled = disabled;
+    button.classList.remove('selected');
+  });
+}
+
+function playCelebration() {
+  celebration.classList.add('active');
+  setTimeout(() => {
+    celebration.classList.remove('active');
+  }, 2200);
+}
+
+function updateStatus() {
+  scoreValue.textContent = score;
+  roundValue.textContent = round;
+  bestValue.textContent = bestStreak;
+}
+
+function setFeedback(message, type) {
+  feedback.textContent = message;
+  feedback.className = `feedback ${type ?? ''}`.trim();
+}
+
+function startGame() {
+  score = 0;
+  round = 0;
+  isRoundActive = false;
+  startButton.textContent = 'Next Friend';
+  setFeedback('', '');
+  updateStatus();
+  nextRound();
+}
+
+function nextRound() {
+  if (round >= MAX_ROUNDS) {
+    setFeedback(`You fed every friend! Final score: ${score}/${MAX_ROUNDS}. Tap Start Picnic to play again.`, 'success');
+    promptText.textContent = 'All the forest friends are full and happy. Wonderful work!';
+    startButton.textContent = 'Play Again';
+    startButton.disabled = false;
+    resetTreatButtons(true);
+    playCelebration();
+    return;
+  }
+
+  round += 1;
+  isRoundActive = true;
+  updateStatus();
+
+  const [animal] = shuffle(animals);
+  currentAnimal = animal;
+
+  animalCard.classList.add('active');
+  animalImage.src = animal.image;
+  animalImage.alt = `${animal.name} illustration`;
+  animalName.textContent = animal.name;
+  animalStory.textContent = animal.story;
+
+  promptText.textContent = `${animal.name.split(' ')[0]} is hungry! Which snack will you share?`;
+  setFeedback('', '');
+
+  resetTreatButtons(false);
+  startButton.disabled = true;
+}
+
+function handleTreatSelection(event) {
+  if (!isRoundActive || !currentAnimal) {
+    return;
+  }
+
+  const button = event.currentTarget;
+  const selectedTreat = button.dataset.treat;
+
+  resetTreatButtons(false);
+  button.classList.add('selected');
+
+  if (selectedTreat === currentAnimal.favoriteTreat) {
+    score += 1;
+    bestStreak = Math.max(bestStreak, score);
+    setFeedback(`Yum! ${currentAnimal.name.split(' ')[0]} loved the ${treatDescriptions[selectedTreat].toLowerCase()}`, 'success');
+  } else {
+    score = Math.max(0, score - 1);
+    setFeedback(`Oops! Try offering the snack that matches the clue.`, 'error');
+  }
+
+  updateStatus();
+  isRoundActive = false;
+  animalCard.classList.remove('active');
+  startButton.disabled = false;
+  startButton.textContent = round >= MAX_ROUNDS ? 'Celebrate Picnic' : 'Next Friend';
+  startButton.focus();
+}
+
+startButton.addEventListener('click', () => {
+  if (round >= MAX_ROUNDS && !isRoundActive) {
+    startGame();
+  } else if (!isRoundActive) {
+    nextRound();
+  }
+});
+
+treatButtons.forEach((button) => {
+  button.addEventListener('click', handleTreatSelection);
+});
+
+resetTreatButtons(true);
+startButton.disabled = false;

--- a/forest-picnic/style.css
+++ b/forest-picnic/style.css
@@ -1,0 +1,307 @@
+:root {
+    --forest-dark: #2d4a3d;
+    --forest-light: #edf7f2;
+    --forest-accent: #6fcf97;
+    --forest-soft: #fdf4e6;
+    --forest-sky: #9ed0ff;
+    --forest-shadow: rgba(45, 74, 61, 0.12);
+    font-family: 'Quicksand', 'Segoe UI', system-ui, sans-serif;
+}
+
+* {
+    box-sizing: border-box;
+}
+
+body {
+    margin: 0;
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    background: radial-gradient(circle at top, var(--forest-sky) 0%, #f7fff3 45%, #ffffff 100%);
+    color: var(--forest-dark);
+    padding: 2rem 1rem;
+}
+
+.game-container {
+    background: rgba(255, 255, 255, 0.92);
+    backdrop-filter: blur(6px);
+    border-radius: 24px;
+    box-shadow: 0 20px 45px var(--forest-shadow);
+    max-width: 960px;
+    width: 100%;
+    padding: 2.5rem 2rem 2.75rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1.75rem;
+    position: relative;
+    overflow: hidden;
+}
+
+.game-container::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: url('assets/background.svg') center/cover no-repeat;
+    opacity: 0.05;
+    pointer-events: none;
+}
+
+.game-header {
+    text-align: center;
+    position: relative;
+    z-index: 1;
+}
+
+.game-header h1 {
+    margin: 0 0 0.5rem;
+    font-size: clamp(2.2rem, 4vw, 2.8rem);
+    letter-spacing: 0.03em;
+}
+
+.game-header p {
+    margin: 0;
+    font-size: clamp(1rem, 2vw, 1.2rem);
+}
+
+.status-bar {
+    display: flex;
+    gap: 0.75rem;
+    justify-content: center;
+    flex-wrap: wrap;
+    position: relative;
+    z-index: 1;
+}
+
+.status-pill {
+    background: linear-gradient(135deg, var(--forest-light), #ffffff);
+    padding: 0.6rem 1.2rem;
+    border-radius: 999px;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.8), 0 8px 16px var(--forest-shadow);
+    font-weight: 600;
+    letter-spacing: 0.02em;
+}
+
+.scene {
+    position: relative;
+    border-radius: 20px;
+    overflow: hidden;
+    background: linear-gradient(180deg, #f1fbff 0%, #fef9f2 100%);
+    padding: clamp(1.5rem, 4vw, 2rem);
+    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.7), 0 15px 30px rgba(92, 139, 104, 0.15);
+    display: grid;
+    grid-template-columns: minmax(180px, 240px) 1fr;
+    align-items: center;
+    gap: 1.5rem;
+    z-index: 1;
+}
+
+.scene-background {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    filter: saturate(1.1);
+    z-index: 0;
+    opacity: 0;
+}
+
+.animal-card {
+    background: rgba(255, 255, 255, 0.88);
+    border-radius: 18px;
+    padding: 1.25rem;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1rem;
+    box-shadow: 0 10px 20px rgba(45, 74, 61, 0.12);
+    position: relative;
+    z-index: 1;
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.animal-card.active {
+    transform: translateY(-6px);
+    box-shadow: 0 14px 30px rgba(45, 74, 61, 0.22);
+}
+
+.animal-card img {
+    width: min(220px, 45vw);
+    height: auto;
+    animation: float 4s ease-in-out infinite;
+}
+
+.animal-details {
+    text-align: center;
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+}
+
+.animal-details h2 {
+    margin: 0;
+    font-size: clamp(1.4rem, 3vw, 1.8rem);
+}
+
+.animal-details p {
+    margin: 0;
+    font-size: clamp(1rem, 2.2vw, 1.15rem);
+    line-height: 1.5;
+}
+
+.prompt {
+    text-align: center;
+    position: relative;
+    z-index: 1;
+}
+
+.prompt p {
+    margin: 0 0 1rem;
+    font-size: clamp(1.05rem, 2.2vw, 1.2rem);
+}
+
+.primary-button {
+    background: linear-gradient(135deg, #ffb36b, #ff7a8a);
+    border: none;
+    border-radius: 999px;
+    color: white;
+    font-weight: 700;
+    font-size: 1.05rem;
+    padding: 0.85rem 2.5rem;
+    cursor: pointer;
+    box-shadow: 0 12px 25px rgba(255, 133, 138, 0.35);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.primary-button:focus-visible,
+.primary-button:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 14px 30px rgba(255, 133, 138, 0.4);
+}
+
+.treat-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: 1rem;
+    position: relative;
+    z-index: 1;
+}
+
+.treat-card {
+    border: none;
+    border-radius: 18px;
+    padding: 1.1rem 1rem 1.25rem;
+    background: linear-gradient(180deg, #ffffff 0%, var(--forest-soft) 100%);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.75rem;
+    font-size: 1.05rem;
+    font-weight: 600;
+    color: var(--forest-dark);
+    cursor: pointer;
+    box-shadow: 0 12px 25px rgba(45, 74, 61, 0.12);
+    transition: transform 0.2s ease, box-shadow 0.2s ease, border 0.2s ease;
+}
+
+.treat-card:focus-visible,
+.treat-card:hover {
+    transform: translateY(-4px);
+    box-shadow: 0 16px 32px rgba(45, 74, 61, 0.18);
+}
+
+.treat-card.selected {
+    border: 3px solid var(--forest-accent);
+}
+
+.treat-card img {
+    width: 120px;
+    height: auto;
+    pointer-events: none;
+}
+
+.treat-card[disabled] {
+    cursor: not-allowed;
+    opacity: 0.55;
+    transform: none;
+    box-shadow: 0 6px 15px rgba(45, 74, 61, 0.08);
+}
+
+.feedback {
+    min-height: 2rem;
+    text-align: center;
+    font-size: 1.15rem;
+    font-weight: 600;
+    color: var(--forest-dark);
+    z-index: 1;
+}
+
+.feedback.success {
+    color: #1b8f58;
+}
+
+.feedback.error {
+    color: #cc3d4a;
+}
+
+.game-footer {
+    text-align: center;
+    font-size: 0.95rem;
+    opacity: 0.8;
+    z-index: 1;
+}
+
+#celebration {
+    position: fixed;
+    inset: 0;
+    pointer-events: none;
+    display: none;
+}
+
+#celebration.active {
+    display: block;
+}
+
+.sparkle {
+    position: absolute;
+    width: 180px;
+    height: 180px;
+    background: radial-gradient(circle, rgba(255, 255, 255, 0.95) 0%, rgba(255, 214, 165, 0.3) 60%, rgba(255, 122, 138, 0) 75%);
+    animation: shimmer 2.8s ease-in-out infinite;
+}
+
+.sparkle-1 { top: 10%; left: 15%; }
+.sparkle-2 { top: 40%; right: 20%; animation-delay: 0.6s; }
+.sparkle-3 { bottom: 12%; left: 45%; animation-delay: 1.2s; }
+
+@keyframes float {
+    0%, 100% { transform: translateY(0); }
+    50% { transform: translateY(-10px); }
+}
+
+@keyframes shimmer {
+    0%, 100% { transform: scale(0.7); opacity: 0.5; }
+    50% { transform: scale(1.05); opacity: 1; }
+}
+
+@media (max-width: 768px) {
+    body {
+        padding: 1.5rem 1rem;
+    }
+
+    .game-container {
+        padding: 2rem 1.25rem;
+    }
+
+    .scene {
+        grid-template-columns: 1fr;
+        text-align: center;
+    }
+}
+
+@media (max-width: 480px) {
+    .treat-card img {
+        width: 90px;
+    }
+}

--- a/index.html
+++ b/index.html
@@ -60,6 +60,18 @@
             </div>
             <a href="princess-coffee-shop/index.html" class="play-button">Play Now</a>
         </div>
+
+        <div class="game-card">
+            <div class="game-icon">🌲</div>
+            <h2>Forest Friends Picnic</h2>
+            <p>Join woodland friends for a cozy picnic! Listen to each animal's clue and serve the snack that matches their favorite treat.</p>
+            <div class="game-features">
+                <span class="feature">🦊 Adorable Characters</span>
+                <span class="feature">🧠 Listening Skills</span>
+                <span class="feature">🌟 Gentle Rewards</span>
+            </div>
+            <a href="forest-picnic/index.html" class="play-button">Play Now</a>
+        </div>
     </main>
 
     <footer>


### PR DESCRIPTION
## Summary
- add the Forest Friends Picnic game with round-based listening and snack selection play
- design bespoke SVG artwork for woodland pals, treats, and the picnic backdrop
- surface the new adventure on the landing page and document it in the collection README

## Testing
- Manually opened the new game in the browser

------
https://chatgpt.com/codex/tasks/task_e_68ddd7124258832684e2ce18273d3b2f