### PR TITLE
Optimize coloring studio mobile layout to prevent scrolling

### DIFF
--- a/coloring-studio/__tests__/coloringStudio.test.js
+++ b/coloring-studio/__tests__/coloringStudio.test.js
@@ -130,4 +130,17 @@ describe('Coloring Studio paint-by-numbers experience', () => {
     expect(paintCells.length).toBeGreaterThan(0);
     expect(paintCells.length).toBeLessThanOrEqual(50);
   });
+
+  test('mobile layout locks the viewport and keeps the studio content visible without scrolling', () => {
+    const styles = Array.from(document.querySelectorAll('style'))
+      .map((styleTag) => styleTag.textContent)
+      .join('\n');
+
+    expect(styles).toMatch(/@media\s*\(max-width:\s*720px\)[\s\S]*body\s*{[\s\S]*overflow:\s*hidden/i);
+    expect(styles).toMatch(/@media\s*\(max-width:\s*720px\)[\s\S]*main\s*{[\s\S]*height:\s*100dvh/i);
+    expect(styles).toMatch(/@media\s*\(max-width:\s*720px\)[\s\S]*main\s*{[\s\S]*overflow:\s*hidden/i);
+    expect(styles).toMatch(/@media\s*\(max-width:\s*720px\)[\s\S]*\.studio\s*{[\s\S]*grid-template-rows:\s*minmax\(0,\s*1fr\)\s*auto/i);
+    expect(styles).toMatch(/@media\s*\(max-width:\s*720px\)[\s\S]*\.canvas-area\s*{[\s\S]*min-height:\s*0/i);
+    expect(styles).toMatch(/@media\s*\(max-width:\s*720px\)[\s\S]*\.canvas-wrapper\s*{[\s\S]*display:\s*flex/i);
+  });
 });

--- a/coloring-studio/index.html
+++ b/coloring-studio/index.html
@@ -244,20 +244,110 @@
 
         @media (max-width: 720px) {
             body {
-                padding: 1rem;
+                display: block;
+                padding: 0;
+                min-height: 100dvh;
+                overflow: hidden;
+            }
+
+            main {
+                width: 100%;
+                height: 100dvh;
+                max-height: 100dvh;
+                border-radius: 0;
+                box-shadow: none;
+                overflow: hidden;
+            }
+
+            header {
+                padding: 1rem 1.25rem 0.85rem;
+                gap: 0.5rem;
+            }
+
+            header p {
+                display: none;
+            }
+
+            .studio {
+                flex: 1;
+                padding: 0.85rem 1.25rem 1rem;
+                display: grid;
+                grid-template-rows: minmax(0, 1fr) auto;
+                gap: 0.75rem;
+                overflow: hidden;
+            }
+
+            .canvas-area {
+                flex: 1;
+                min-height: 0;
+                padding: 0.65rem;
+                border-radius: 18px;
+                gap: 0.65rem;
+            }
+
+            .canvas-wrapper {
+                flex: 1;
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                min-height: 0;
+                padding: 0.5rem;
+            }
+
+            svg {
+                height: 100%;
+                max-height: none;
+            }
+
+            .toolbar {
+                display: grid;
+                grid-template-areas:
+                    'palette'
+                    'actions';
+                gap: 0.75rem;
             }
 
             .palette {
-                grid-template-columns: repeat(auto-fit, minmax(70px, 1fr));
+                grid-area: palette;
+                display: grid;
+                grid-template-columns: repeat(4, minmax(0, 1fr));
+                gap: 0.5rem;
             }
 
             .color-swatch {
-                padding: 0.65rem 0.4rem;
+                padding: 0.45rem 0.35rem;
+                font-size: 0.7rem;
+                gap: 0.35rem;
             }
 
+            .swatch-preview {
+                width: 28px;
+                height: 28px;
+            }
+
+            .actions {
+                grid-area: actions;
+                display: flex;
+                flex-wrap: wrap;
+                justify-content: center;
+                gap: 0.5rem;
+            }
+
+            .action-button {
+                flex: 1 1 calc(50% - 0.5rem);
+                justify-content: center;
+                padding: 0.65rem 0.75rem;
+                font-size: 0.8rem;
+            }
+
+            .numbers-hint,
             .legend {
-                flex-direction: column;
-                gap: 0.75rem;
+                display: none;
+            }
+
+            footer {
+                padding: 0.65rem 1rem 0.85rem;
+                font-size: 0.75rem;
             }
         }
     </style>


### PR DESCRIPTION
## Summary
- lock the coloring studio mobile layout to the viewport height so the canvas and palette stay visible together
- streamline toolbar spacing and typography on small screens to fit without scrolling
- add a regression test that verifies the mobile stylesheet enforces the no-scrolling guardrails

## Testing
- npm test -- coloring-studio

------
https://chatgpt.com/codex/tasks/task_e_68e69f0c86b883268932aaa9e3b2d90a